### PR TITLE
QSE-80: Add workspace ID in ouputs (patch)

### DIFF
--- a/modules/log-analytics-workspace/outputs.tf
+++ b/modules/log-analytics-workspace/outputs.tf
@@ -8,6 +8,11 @@ output "id" {
   value       = azurerm_log_analytics_workspace.workspace.id
 }
 
+output "workspace_id" {
+  description = "The workspace or customer ID of the Log Analytics workspace."
+  value       = azurerm_log_analytics_workspace.workspace.workspace_id
+}
+
 output "portal_url" {
   description = "The Portal URL for the Log Analytics workspace."
   value       = azurerm_log_analytics_workspace.workspace.portal_url


### PR DESCRIPTION
Workspace ID was not present in outputs in package. Added that for log collector deployment requirement.